### PR TITLE
fix `v2` protocol response

### DIFF
--- a/app/Http/Controllers/Api/V2/ApplicationApiController.php
+++ b/app/Http/Controllers/Api/V2/ApplicationApiController.php
@@ -61,7 +61,7 @@ class ApplicationApiController extends Controller
         }
 
         return ApplicationUpdateResource::make($newBuild)
-            ->additional(['forced' => optional($currentBuild)->dismissed ?? false]);
+            ->withForcedFlag(optional($currentBuild)->dismissed ?? false);
     }
 
 }

--- a/app/Http/Resources/V2/ApplicationUpdateResource.php
+++ b/app/Http/Resources/V2/ApplicationUpdateResource.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace App\Http\Resources\V2;
 
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -7,16 +8,32 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class ApplicationUpdateResource extends JsonResource
 {
     /**
+     * @var bool
+     */
+    private $forced = false;
+
+    /**
      * Transform the resource into an array.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param  \Illuminate\Http\Request  $request
      * @return array
      */
     public function toArray($request)
     {
         return [
+            'forced' => $this->forced,
             'version' => $this->version,
-            'download_url' => url('/applications/' . $this->application->slug . '/' . $this->platform),
+            'download_url' => url(sprintf("/applications/%s/%s", $this->application->slug, $this->platform)),
         ];
+    }
+
+    /**
+     * @param  bool  $flag
+     * @return $this
+     */
+    public function withForcedFlag(bool $flag): ApplicationUpdateResource
+    {
+        $this->forced = $flag;
+        return $this;
     }
 }

--- a/tests/Feature/Http/Controllers/Api/V2/ApplicationApiControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/V2/ApplicationApiControllerTest.php
@@ -328,7 +328,7 @@ class ApplicationApiControllerTest extends TestCase
 
         $response->assertSuccessful();
         $this->assertSame('1.1.1', $response->json('data.version'));
-        $this->assertTrue($response->json('forced'));
+        $this->assertTrue($response->json('data.forced'));
     }
 
 }


### PR DESCRIPTION
The `forced` flag ended up outside the `data` wrapping
```json
{
  "data": {
    "version": "YYY",
    "download_url": "XXX"
  },
  "forced": false
}
```
Correct one:

```json
{
  "data": {
    "forced": false
    "version": "YYY",
    "download_url": "XXX"
  }
}
```